### PR TITLE
standardize

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -65,4 +65,3 @@ function setup () {
 function cleanup () {
   rimraf.sync(testDBpath)
 }
-


### PR DESCRIPTION
I think `eslint` got better at detecting multiple blank lines at the end of a file. And the `standard` tests caught this`

This PR just removes the extra line at the end of `test/basic.js`
